### PR TITLE
Set variable field and enforce set uniqueness

### DIFF
--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -438,7 +438,7 @@ def wholeSetPredicate(field_set):
 
 def commonSetElementPredicate(field_set):
     """return set as individual elements"""
-    return tuple([str(each) for each in field_set])
+    return tuple(sorted(set(str(each) for each in field_set)))
 
 
 def commonTwoElementsPredicate(field):

--- a/dedupe/variables/set.py
+++ b/dedupe/variables/set.py
@@ -1,7 +1,9 @@
+import itertools
+
 from .base import FieldType
 from dedupe import predicates
 from simplecosine.cosine import CosineSetSimilarity
-
+from affinegap import normalizedAffineGapDistance as affineGap
 
 class SetType(FieldType):
     type = "Set"
@@ -25,3 +27,32 @@ class SetType(FieldType):
             definition['corpus'] = []
 
         self.comparator = CosineSetSimilarity(definition['corpus'])
+
+
+class MinDistanceSetType(SetType):
+    type = "MinDistanceSet"
+
+    def __init__(self, definition):
+        super().__init__(definition)
+        if 'corpus' not in definition:
+            definition['corpus'] = []
+
+        self.comparator = affine_set_similarity
+
+
+def affine_set_similarity(string1, string2):
+    assert(isinstance(string1, (list, tuple, set)))
+    assert(isinstance(string2, (list, tuple, set)))
+
+    closest_distance = None
+    for (w1, w2) in itertools.product(string1, string2):
+        if (not w1) or (not w2):
+            continue
+
+        distance = affineGap(w1, w2)
+        if closest_distance is None:
+            closest_distance = distance
+        else:
+            closest_distance = min(distance, closest_distance)
+
+    return closest_distance


### PR DESCRIPTION
    variables/set: enforce set uniqueness; add new set FieldType
    
    - non-unique sets cause a lot of problems downstream; checking
      for uniqueness appears to have a small performance impact
      so long as sets are relatively small
    - added MinDistanceSetType which shares the same predicates
      as SetType, but uses the minimum affine string distance
      between set elements; this allows for matching partial string
      matches between the sets; performance cost scales O(n^2) with
      set size